### PR TITLE
Add prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "material-ui": "^0.18.0",
+    "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-tap-event-plugin": "^2.0.1"

--- a/src/ErrorReporting/index.js
+++ b/src/ErrorReporting/index.js
@@ -1,8 +1,8 @@
 // -*- mode: rjsx -*-
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Snackbar from 'material-ui/Snackbar';
 import {red900, grey50} from 'material-ui/styles/colors';
-
 
 class ErrorReporting extends Component {
 
@@ -31,15 +31,15 @@ class ErrorReporting extends Component {
     };
 
     static propTypes = {
-        open: React.PropTypes.bool,
-        action: React.PropTypes.string,
-        error: React.PropTypes.instanceOf(Error),
-        autoHideDuration: React.PropTypes.number,
-        getMessage: React.PropTypes.func,
-        style: React.PropTypes.object,
-        contentStyle: React.PropTypes.object,
-        onError: React.PropTypes.func,
-        onClose: React.PropTypes.func
+        open: PropTypes.bool,
+        action: PropTypes.string,
+        error: PropTypes.instanceOf(Error),
+        autoHideDuration: PropTypes.number,
+        getMessage: PropTypes.func,
+        style: PropTypes.object,
+        contentStyle: PropTypes.object,
+        onError: PropTypes.func,
+        onClose: PropTypes.func
     };
 
     exclusiveProps = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,21 +999,9 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.6:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1414,7 +1402,7 @@ lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1620,6 +1608,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.8"


### PR DESCRIPTION
This adds the `prop-types` module dependency and updates the `ErrorReporting` component to use the new module, since accessing PropTypes from the main React package is deprecated.

This fixes the warning: `Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`